### PR TITLE
Improve documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ Full options:
         Interval to print stats (default 1m0s)
   -statsfile string
         File to load/store statistics data (default "stressdisk_stats.json")
+
+Note that flags must be provided BEFORE the stressdisk command, eg
+  stressdisk -duration 48h run /mnt
 ```
 
 Quickstart

--- a/README.md
+++ b/README.md
@@ -24,10 +24,16 @@ Download the relevant binary from
 
 Or alternatively if you have Go installed use
 
-    go get github.com/ncw/stressdisk
+    go install github.com/ncw/stressdisk@latest
 
-and this will build the binary in `$GOPATH/bin`.  You can then modify
-the source and submit patches.
+If you want to modify the sources, it is recommended to check out the repository.
+
+    git clone https://github.com/ncw/stressdisk.git
+    cd stressdisk
+    go mod init github.com/ncw/stressdisk
+    go build .
+
+You can then modify the source, rebuild as needed, and submit patches.
 
 Usage
 -----

--- a/stressdisk.go
+++ b/stressdisk.go
@@ -549,6 +549,10 @@ Manual usage:
 Full options:
 `, version)
 	flag.PrintDefaults()
+	fmt.Fprintf(os.Stderr, `
+Note that flags must be provided BEFORE the stressdisk command, eg
+  stressdisk -duration 48h run /mnt
+`)
 }
 
 // Exit with the message
@@ -561,7 +565,9 @@ func fatalf(message string, args ...interface{}) {
 // checkArgs checks there are enough arguments and prints a message if not
 func checkArgs(args []string, n int, message string) {
 	if len(args) != n {
-		fatalf("%d arguments required: %s\n", n, message)
+		fatalf("%d arguments required: %s\n"+
+			"Make sure flags are listed before the command, eg\n"+
+			"stressdisk -duration 24h run /mnt\n", n, message)
 	}
 }
 

--- a/stressdisk.go
+++ b/stressdisk.go
@@ -59,7 +59,7 @@ const (
 // Globals
 var (
 	// Flags
-	fileSize      = flag.Int64("s", 1E9, "Size of the check files")
+	fileSize      = flag.Int64("s", 1e9, "Size of the check files")
 	cpuprofile    = flag.String("cpuprofile", "", "Write cpu profile to file")
 	duration      = flag.Duration("duration", time.Hour*24, "Duration to run test")
 	statsInterval = flag.Duration("stats", time.Minute*1, "Interval to print stats")


### PR DESCRIPTION
Tried to run stressdisk today and ran into some issues which sent me on a bit of a debug path. First the order of arguments is confusing, and then the format of the duration (duration format not as big a deal but I did include it in my one example just so it's clear how it's used in a real command).

Not really a go developer so feel free to change anything, particularly the documentation I edited on building/installing. go get didn't work for me, it told me to use go install, and GOPATH doesn't seem to be used either (unless they have a fallback which defaults to `~/go`, whatever it is, I know I don't have GOPATH set in my environment).